### PR TITLE
Upgrade pyroute2 on Ussuri to 0.5.13

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -260,7 +260,7 @@ semantic-version===2.8.4
 virtualbmc===2.0.0
 deprecation===2.0.7
 SQLAlchemy===1.3.16
-pyroute2===0.5.11
+pyroute2===0.5.13
 google-auth===1.13.1
 kazoo===2.7.0
 XStatic-roboto-fontface===0.5.0.0


### PR DESCRIPTION
This allows us to profit from a link_lookup optimization, which has a big impact on our interface wiring speed in neutron linuxbridge agent:

https://github.com/svinota/pyroute2/blob/32f5fa09b4190b502505a207700c700843d1793a/CHANGELOG.rst?plain=1#L141